### PR TITLE
feat: add GitHub Actions deploy workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,37 @@
+name: Deploy Keycloak Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker Tag'
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: Keycloak Dev
+      url: https://login-dev.mbtace.com/
+    concurrency: dev
+    env:
+      ECS_CLUSTER: keycloak
+      ECS_SERVICE: keycloak-dev
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mbta/actions/deploy-ecs@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
+          # TODO once image is built locally, remove DOCKER_REPO and
+          # get this value from the build-push-ecr step
+          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.docker_tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,37 @@
+name: Deploy Keycloak Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker Tag'
+        required: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: Keycloak Prod
+      url: https://login.mbta.com/
+    concurrency: prod
+    env:
+      ECS_CLUSTER: keycloak
+      ECS_SERVICE: keycloak-prod
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: mbta/actions/deploy-ecs@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          ecs-cluster: ${{ env.ECS_CLUSTER }}
+          ecs-service: ${{ env.ECS_SERVICE }}
+          # TODO once image is built locally, remove DOCKER_REPO and
+          # get this value from the build-push-ecr step
+          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.docker_tag }}
+      - uses: mbta/actions/notify-slack-deploy@v1
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          job-status: ${{ job.status }}


### PR DESCRIPTION
## Considerations

Support deployment of Keycloak to ECS using MBTA's [`deploy-ecs` action](https://github.com/mbta/actions/tree/main/deploy-ecs). Once merged, will allow for deploying Keycloak dev and prod via the "Actions" tab in this repo.

## Caveats

Since Keycloak Docker images are not currently being deployed out of this repo, workflow runs currently require the Docker image version to be provided as an input. These values must be provided by Integsoft. Once Integsoft has pushed the container image assets to this repo, we can implement build/push locally, and remove the manual input.

Some changes were required to the `terraform-keycloak-sso` Terraform module to support GitHub Actions deployment:

- https://github.com/mbta/terraform-keycloak-sso/commit/9fe3b2b76ebf6e571722813e2259eb35f95af9b1
- https://github.com/mbta/terraform-keycloak-sso/commit/10b233764ba2c34ab5200b38774a021b4f68ea91
- https://github.com/mbta/terraform-keycloak-sso/commit/de8f07af157bea3e4795ce23a46b423db449c6a1

To support deployment, all Keycloak clusters should be provisioned using v0.4.2 of the `terraform-keycloak-sso` module or greater.

Once this change is merged, I'll need to add the following secrets to the repo configuration:

- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (an IAM user will be created specifically for this repo)
- `DOCKER_REPO` (the URL of the ECR repo where Integsoft's Keycloak Docker images are stored currently)