### PR TITLE
feat: build container images locally

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,25 @@
+name: Build Container Image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-image:
+    name: Build Container Image
+    runs-on: ubuntu-latest
+    concurrency: build-image
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get pushed tag name
+        id: vars
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-tags: ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,11 +1,9 @@
 name: Deploy Keycloak Dev
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
-    inputs:
-      docker_tag:
-        description: 'Docker Tag'
-        required: true
 
 jobs:
   deploy:
@@ -21,15 +19,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: mbta/actions/build-push-ecr@v1
+        id: build-push
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
+          docker-additional-tags: dev
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
-          # TODO once image is built locally, remove DOCKER_REPO and
-          # get this value from the build-push-ecr step
-          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.docker_tag }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -3,8 +3,8 @@ name: Deploy Keycloak Prod
 on:
   workflow_dispatch:
     inputs:
-      docker_tag:
-        description: 'Docker Tag'
+      tag:
+        description: 'Existing Tag to Deploy'
         required: true
 
 jobs:
@@ -20,16 +20,13 @@ jobs:
       ECS_SERVICE: keycloak-prod
 
     steps:
-      - uses: actions/checkout@v2
       - uses: mbta/actions/deploy-ecs@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
-          # TODO once image is built locally, remove DOCKER_REPO and
-          # get this value from the build-push-ecr step
-          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.docker_tag }}
+          docker-tag: ${{ secrets.DOCKER_REPO }}:${{ github.event.inputs.tag }}
       - uses: mbta/actions/notify-slack-deploy@v1
         if: ${{ !cancelled() }}
         with:

--- a/README.md
+++ b/README.md
@@ -1,61 +1,28 @@
-# keycloak-deploy
+# Keycloak Deploy
 
-These scripts do the following:
+Assets, customizations and tooling to build and deploy Keycloak containers to ECS.
 
-- create a Docker image to run Keycloak (based on the `jboss/keycloak` image)
-- upload that image to AWS Elastic Container Service
-- deploy an environmment using that image to AWS Elastic Beanstalk
+## Building &amp; Deploying
 
-## Usage
+This repo contains GitHub Actions workflows for:
 
-```
-$ semaphore/build_push.sh dev
-$ semaphore/deploy.sh dev
-```
+- Building a Docker container image whenever a git tag is created
+- Deploying to Keycloak Dev whenever changes are merged to the main branch
+- Deploying pre-existing tags to Keycloak Prod
 
-## Requirements
+These workflows are designed to support the following code deployment process:
 
-- an RDS PostgreSQL database, configured with a user accessible with IAM access
+1. Propose changes in a pull request and have them reviwed.
+1. When the pull request is approved, merge it into the main branch. This will automatically trigger the [Deploy Keycloak Dev](https://github.com/mbta/keycloak-deploy/actions/workflows/deploy-dev.yml) workflow.
+1. Confirm that Keycloak Dev is in a good state after the deploy.
+1. [Create a new Release](https://github.com/mbta/keycloak-deploy/releases) in GitHub. In the release creation form:
+   - Create a new tag for the release. The tag should start with the letter `v` and use [semantic versioning](https://semver.org/), e.g. `v1.0.3`.
+   - Set the release title to match the tag
+   - In the release description, note the changes that are part of this release
+   When the release is created, the [Build Container Image](https://github.com/mbta/keycloak-deploy/actions/workflows/build-image.yml) workflow will run automatically to build an image with the corresponding tag and push it to ECR.
+1. Deploy to production by running the [Deploy Keycloak Prod](https://github.com/mbta/keycloak-deploy/actions/workflows/deploy-prod.yml) workflow, passing the newly created tag.
 
-### RDS configuration
+## Maintainers
 
-To create an IAM user, run the following in the database:
-
-```
-create user USER with login;
-grant rds_iam to USER;
-grant connect on database DATABASE_NAME to USER;
-grant usage on schema public to USER;
-alter default privileges in schema public grant all privileges on tables to USER;
-alter default privileges in schema public grant all privileges on sequences to USER;
-```
-
-## Configuration
-
-The following environment variables should be configured locally, in order to deploy to Elastic Beanstalk:
-
-- `APP` - the Elastic Beanstalk application
-- `DOCKER_REPO` - the Elastic Container Service Docker repository
-- `S3_BUCKET_NAME` - the S3 bucket to which Elastic Beanstalk versions are uploaded
-
-The following environment variables should be configured in the Elastic Beanstalk environment:
-
-- `DB_REGION` - the region the database server is running in
-- `DB_NAME` - the name of the database
-- `DB_ADDR` - the hostname of the database server
-- `DB_PORT` - the port of the database server
-- `DB_USER` - the username for the database
-- `KEYCLOAK_HOSTNAME` - the public hostname for Keycloak
-- `KEYCLOAK_ADMIN_USER_SECRET` - an AWS Secrets Manager secret with the
-  username/password for the default admin user
-
-## TODOs
-
-- [] have the load balancer connect to Nginx over TLS
-- [] test that multiple instances connect via the database appropriately
-
-## Kudos
-
-Thank you to
-[dasniko/keycloak-docker-aws](https://github.com/dasniko/keycloak-docker-aws)
-for help with the JDBC_PING adapter and getting data from AWS Secrets Manager.
+- [Integsoft](https://www.integsoft.com/home.html)
+- [MBTA Customer Technology](https://ctd.mbta.com/)


### PR DESCRIPTION
## Considerations

- Add GitHub Actions workflow to build and push image on tag creation
- Modify "Deploy Keycloak Dev" workflow to:
  - Run only on push to main branch
  - Build and push container image as part of deploy
  - Tag `dev` in addition to git-based tag
- Modify "Deploy Keycloak Prod" workflow to only deploy a previously-tagged image
- Update README.md:
  - Remove outdated information
  - Describe GitHub Actions code deployment process for dev &amp; prod

Note that the proposed deployment process should be as much a part of this review as the code itself. See [the new README.md](https://github.com/mbta/keycloak-deploy/blob/idw-docker-build/README.md) for details on how the process is expected to work.

## Tested

Using [a fork of this repo](https://github.com/ianwestcott/keycloak-deploy/actions), I successfully tested:

- Automatic "Build Container Image" workflow run on Release/tag creation
- Automatic "Deploy Keycloak Dev" workflow run on push to main branch
- Deploy using existing tag (by changing "Deploy Keycloak Prod" to point to dev and then running it by passing an existing tag)

## TODO

Once this is approved and merged, I'll:

- Add Releases/tags for the recent changes pushed to this repo: `v1.0.6`, `v1.0.7`
- Update the value of the `DOCKER_REPO` secret in the repo settings to point to the Keycloak ECR Repo in CTD's main AWS account
- Review and merge https://github.com/mbta/keycloak-deploy/pull/4
- Verify deploy to Keycloak Dev
- Tag `v1.0.8` and deploy to Keycloak Prod