### PR TITLE
Chore: Update action to v2

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -10,6 +10,9 @@ jobs:
     name: Build Container Image
     runs-on: ubuntu-latest
     concurrency: build-image
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Get pushed tag name
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
-      - uses: mbta/actions/build-push-ecr@v1
+      - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           docker-repo: ${{ secrets.DOCKER_REPO }}
           docker-additional-tags: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
I missed this action as part of October's updates. V2 of build-push-ecr uses an assumed role instead of long-lasting AWS keys. These keys were deleted, as well as the repo secret