### PR TITLE
Enable local template dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,6 @@ WORKDIR /opt/keycloak
 # Ports
 EXPOSE 8080 8443
 
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--optimized"]
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh"]
+
+CMD ["start", "--optimized"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,14 @@ services:
       - JAVA_OPTS_APPEND=-Xmx1500m -Djboss.bind.address=0.0.0.0
       - AWS_REGION=us-east-1
       - KC_HEALTH_ENABLED=true
-    links:
+    command:
+      - "start-dev"
+      - "--spi-theme-static-max-age=1"
+      - "--spi-theme-cache-themes=false"
+      - "--spi-theme-cache-templates=false"
+    volumes:
+      - ./files/templates/mbta:/opt/keycloak/themes/mbta
+    depends_on:
       - mariadb
   mariadb:
     image: mariadb:latest


### PR DESCRIPTION
This PR modifies the Docker local configuration to start up Keycloak in dev mode with theme caching disabled in order to make it easier to do template development locally.

Production Keycloak runtime mode via the `Dockerfile` should be unchanged.

This also comments out some template variables that seem to have been removed in v22.0.0, but not removed from the mbta account theme, as they were failing a page load when testing this.

cc @lukecamelo @io-mike 