### PR TITLE
style: fixes for Safari checkboxes and Password Strength text sizes

### DIFF
--- a/files/templates/mbta/login/resources/css/stylesheet.css
+++ b/files/templates/mbta/login/resources/css/stylesheet.css
@@ -87,6 +87,14 @@ h3 {
     .header-container {
         width: 70% !important;
     }
+
+    .required-pill {
+      font-size: 0.875rem;
+    }
+
+    .strength-container {
+      font-size: 0.875rem;
+    }
 }
 
 /* reduce content width for LG/XL breakpoint */
@@ -112,6 +120,14 @@ h3 {
 
     h3 {
         font-size: 1.4763rem;
+    }
+    
+    .required-pill {
+      font-size: 1rem;
+    }
+
+    .strength-container {
+      font-size: 1rem;
     }
 }
 
@@ -499,6 +515,7 @@ a:visited {
 
 .checkbox-input-group {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
 }
 
@@ -563,7 +580,6 @@ a:visited {
 }
 
 .strength-container {
-    font-size: 1rem;
     display: none;
     background-color: #F4F5F7;
     padding: .5rem;


### PR DESCRIPTION
- required pill and password strength text will be 14px for mobile sizes, and 16px for XL sizes similar to how we were scaling font sizes in other places
- checkbox-input-group now aligns in the center, fixing a bug on Safari where they were misaligned