### PR TITLE
fix: style, required text and voiceover fixes

### DIFF
--- a/files/templates/mbta/login/messages/messages_en.properties
+++ b/files/templates/mbta/login/messages/messages_en.properties
@@ -35,6 +35,7 @@ registerTitle=Create Your MBTA Account
 loginProfileTitle=Update your MBTA account
 countryCode=Country code
 showPassword=Show password
+requiredText=Required
 
 missingFirstNameMessage=Please enter your first name.
 missingLastNameMessage=Please enter your last name.
@@ -87,6 +88,7 @@ passwordStrength.two="Average"
 passwordStrength.three="Good"
 passwordStrength.four="Great"
 
+passwordRequirement.label=Password requirements:
 passwordRequirement.uppercase=1 uppercase letter
 passwordRequirement.lowercase=1 lowercase letter
 passwordRequirement.number=1 number

--- a/files/templates/mbta/login/messages/messages_es.properties
+++ b/files/templates/mbta/login/messages/messages_es.properties
@@ -24,6 +24,7 @@ registerTitle=Crea tu cuenta MBTA
 loginProfileTitle=Actualiza tu cuenta MBTA
 countryCode=Código de país
 showPassword=Mostrar contraseña
+requiredText=Requerido
 
 missingFirstNameMessage=Por favor, introduce tu nombre.
 missingLastNameMessage=Ingresa tu apellido.
@@ -76,6 +77,7 @@ passwordStrength.two="Promedio"
 passwordStrength.three="Buena"
 passwordStrength.four="Excelente"
 
+passwordRequirement.label=Requisitos de contraseña:
 passwordRequirement.uppercase=1 letra mayúscula
 passwordRequirement.lowercase=1 letra minúscula
 passwordRequirement.number=1 número

--- a/files/templates/mbta/login/messages/messages_ht.properties
+++ b/files/templates/mbta/login/messages/messages_ht.properties
@@ -24,6 +24,7 @@ registerTitle=Kreye kont MBTA ou
 loginProfileTitle=Mizajou kont MBTA ou
 countryCode=Kòd peyi
 showPassword=Montre modpas
+requiredText=Obligatwa
 
 missingFirstNameMessage=Tanpri antre premye non ou.
 missingLastNameMessage=Tanpri antre non dènye ou.
@@ -76,6 +77,7 @@ passwordStrength.two="Mwayèn"
 passwordStrength.three="Bon"
 passwordStrength.four="Ekselan"
 
+passwordRequirement.label=Kondisyon pou modpas:
 passwordRequirement.uppercase=1 lèt majiskil
 passwordRequirement.lowercase=1 lèt miniskil
 passwordRequirement.number=1 chif

--- a/files/templates/mbta/login/messages/messages_pt.properties
+++ b/files/templates/mbta/login/messages/messages_pt.properties
@@ -24,6 +24,7 @@ registerTitle=Crie sua conta MBTA
 loginProfileTitle=Atualize sua conta MBTA
 countryCode=Código do país
 showPassword=Hiển thị mật khẩu
+requiredText=Obrigatório
 
 missingFirstNameMessage=Por favor, insira seu primeiro nome.
 missingLastNameMessage=Por favor, insira seu sobrenome.
@@ -76,6 +77,7 @@ passwordStrength.two="Média"
 passwordStrength.three="Boa"
 passwordStrength.four="Ótima"
 
+passwordRequirement.label=Requisitos de senha:
 passwordRequirement.uppercase=1 letra maiúscula
 passwordRequirement.lowercase=1 letra minúscula
 passwordRequirement.number=1 número

--- a/files/templates/mbta/login/messages/messages_pt.properties
+++ b/files/templates/mbta/login/messages/messages_pt.properties
@@ -23,7 +23,7 @@ user.attributes.phone_number.span=(opcional para notificações por texto)
 registerTitle=Crie sua conta MBTA
 loginProfileTitle=Atualize sua conta MBTA
 countryCode=Código do país
-showPassword=Hiển thị mật khẩu
+showPassword=Mostrar senha
 requiredText=Obrigatório
 
 missingFirstNameMessage=Por favor, insira seu primeiro nome.

--- a/files/templates/mbta/login/messages/messages_vi.properties
+++ b/files/templates/mbta/login/messages/messages_vi.properties
@@ -23,7 +23,8 @@ user.attributes.phone_number.span= (tùy chọn cho thông báo văn bản)
 registerTitle=Tạo tài khoản MBTA của bạn
 loginProfileTitle=Cập nhật tài khoản MBTA của bạn
 countryCode=Mã quốc gia
-showPassword=Show password
+showPassword=Hiển thị mật khẩu
+requiredText=Yêu cầu
 
 missingFirstNameMessage=Vui lòng nhập tên của bạn.
 missingLastNameMessage=Vui lòng nhập họ của bạn.
@@ -76,6 +77,7 @@ passwordStrength.two="Trung bình"
 passwordStrength.three="Tốt"
 passwordStrength.four="Tuyệt vời"
 
+passwordRequirement.label=Yêu cầu về mật khẩu:
 passwordRequirement.uppercase=1 chữ cái viết hoa
 passwordRequirement.lowercase=1 chữ cái viết thường
 passwordRequirement.number=1 số

--- a/files/templates/mbta/login/messages/messages_zh_CN.properties
+++ b/files/templates/mbta/login/messages/messages_zh_CN.properties
@@ -24,6 +24,7 @@ registerTitle=创建你的 MBTA 账户
 loginProfileTitle=更新你的 MBTA 账户
 countryCode=国家代码
 showPassword=显示密码
+requiredText=必需的
 
 missingFirstNameMessage=请输入你的名字。
 missingLastNameMessage=请输入你的姓氏。
@@ -76,6 +77,7 @@ passwordStrength.two="一般"
 passwordStrength.three="良好"
 passwordStrength.four="优秀"
 
+passwordRequirement.label=密码要求：
 passwordRequirement.uppercase=1 个大写字母
 passwordRequirement.lowercase=1 个小写字母
 passwordRequirement.number=1 个数字

--- a/files/templates/mbta/login/messages/messages_zh_TW.properties
+++ b/files/templates/mbta/login/messages/messages_zh_TW.properties
@@ -24,6 +24,7 @@ registerTitle=創建您的 MBTA 帳戶
 loginProfileTitle=更新您的 MBTA 帳戶
 countryCode=國家代碼
 showPassword=顯示密碼
+requiredText=必需的
 
 missingFirstNameMessage=請輸入您的名字。
 missingLastNameMessage=請輸入您的姓氏。
@@ -76,6 +77,7 @@ passwordStrength.two="平均"
 passwordStrength.three="好"
 passwordStrength.four="非常好"
 
+passwordRequirement.label=密碼要求：
 passwordRequirement.uppercase=1 個大寫字母
 passwordRequirement.lowercase=1 小寫字母
 passwordRequirement.number=1 號

--- a/files/templates/mbta/login/password_strength.ftl
+++ b/files/templates/mbta/login/password_strength.ftl
@@ -1,19 +1,39 @@
 <#macro password_strength_feedback>
-	<div class="form-group" id=password-strength-container style="display: none" tabindex="0">
+	<div class="form-group" id=password-strength-container>
+    <div class="password-requirements-group" id="password-requirements-group" aria-labelledby="password-requirements-label required-upper required-lower required-number required-special required-length" tabindex="0" role="status">
+      <div id="password-requirements-label" class="password-requirements-label">
+        <div>${msg("passwordRequirement.label")}</div>
+      </div>
+      <div id="password-requirements" class="password-requirements">
+        <div class="required-pill" id="required-upper">
+          <img class="required-pill-icon" id="required-upper-icon" src="${url.resourcesPath}/img/password-incomplete.svg"/>
+          <span class="required-pill-text" id="required-upper-text">${msg("passwordRequirement.uppercase")}</span>
+        </div>
 
-    <div id="passwordRequirementsLabel" class="password-requirements-label">
-      <span>Password must contain:</span>
-    </div>
-    <div id="passwordRequirements" class="password-requirements">
-      <div class="required-pill" id="required-upper">${msg("passwordRequirement.uppercase")}</div>
-      <div class="required-pill" id="required-lower">${msg("passwordRequirement.lowercase")}</div>
-      <div class="required-pill" id="required-number">${msg("passwordRequirement.number")}</div>
-      <div class="required-pill" id="required-special">${msg("passwordRequirement.specialCharacter")}</div>
-      <div class="required-pill" id="required-length">${msg("passwordRequirement.length")}</div>
+        <div class="required-pill" id="required-lower">
+          <img class="required-pill-icon" id="required-lower-icon" src="${url.resourcesPath}/img/password-incomplete.svg"/>
+          <div class="required-pill-text">${msg("passwordRequirement.lowercase")}</div>
+        </div>
+
+        <div class="required-pill" id="required-number">
+          <img class="required-pill-icon" id="required-number-icon" src="${url.resourcesPath}/img/password-incomplete.svg"/>
+          <div class="required-pill-text">${msg("passwordRequirement.number")}</div>
+        </div>
+
+        <div class="required-pill" id="required-special">
+          <img class="required-pill-icon" id="required-special-icon" src="${url.resourcesPath}/img/password-incomplete.svg"/>
+          <div class="required-pill-text">${msg("passwordRequirement.specialCharacter")}</div>
+        </div>
+
+        <div class="required-pill" id="required-length">
+          <img class="required-pill-icon" id="required-length-icon" src="${url.resourcesPath}/img/password-incomplete.svg"/>
+          <div class="required-pill-text">${msg("passwordRequirement.length")}</div>
+        </div>
+      </div>
     </div>
 
-    <div id="strengthContainer" class="strength-container">
-      <div class="strength-label">${msg("passwordStrength.text")}&nbsp;<span class="strength-value" id="strengthValue">-</span></div>
+    <div id="strength-container" class="strength-container" aria-labelledby="strength-label strength-description" tabindex="0">
+      <div class="strength-label" id="strength-label">${msg("passwordStrength.text")}&nbsp;<span class="strength-value" id="strengthValue">-</span></div>
       <div class="strength-bar">
         <div class="strength-segment" id="strength-segment-0"></div>
         <div class="strength-segment" id="strength-segment-1"></div>
@@ -27,11 +47,14 @@
       </ul>
     </div>
 
+    <div id="screen-reader-announcer" class="screen-reader-announcer" aria-live="polite"></div>
+
     <script src="${url.resourcesPath}/js/zxcvbn-ts.core.min.js"></script>
     <script src="${url.resourcesPath}/js/zxcvbn-ts.language-common.min.js"></script>
     <script src="${url.resourcesPath}/js/update-password-strength.js"></script>
     <script src="${url.resourcesPath}/js/check-password-strength.js"></script>
     <script type="text/javascript">
+      const resourcesPath = "${url.resourcesPath}";
       document.getElementById('password-strength-container').style.display = "block";
 
 

--- a/files/templates/mbta/login/register.ftl
+++ b/files/templates/mbta/login/register.ftl
@@ -60,10 +60,11 @@
 			
 	        <form id="register-form" action="${url.registrationAction}" method="post">
 	            <div class="form-group">
-	                    <label for="firstName" class="form-input-label<#if messagesPerField.existsError('firstName')> label-error</#if>">${msg("firstName")}</label>
+	                    <label for="firstName" class="form-input-label<#if messagesPerField.existsError('firstName')> label-error</#if>">${msg("firstName")} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                    <input type="text" id="firstName" class="form-input<#if messagesPerField.existsError('firstName')> input-error</#if>" name="firstName"
 	                           value="${(register.formData.firstName!'')}"
 	                           aria-invalid="<#if messagesPerField.existsError('firstName')>true</#if>"
+                             required
 	                    />
 	
 	                    <#if messagesPerField.existsError('firstName')>
@@ -76,10 +77,11 @@
 	            </div>
 	
 	            <div class="form-group">
-	                    <label for="lastName" class="form-input-label<#if messagesPerField.existsError('lastName')> label-error</#if>">${msg("lastName")}</label>
+	                    <label for="lastName" class="form-input-label<#if messagesPerField.existsError('lastName')> label-error</#if>">${msg("lastName")} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                    <input type="text" id="lastName" class="form-input<#if messagesPerField.existsError('lastName')> input-error</#if>" name="lastName"
 	                           value="${(register.formData.lastName!'')}"
 	                           aria-invalid="<#if messagesPerField.existsError('lastName')>true</#if>"
+                             required
 	                    />
 	
 	                    <#if messagesPerField.existsError('lastName')>
@@ -92,10 +94,11 @@
 	            </div>
 	
 	            <div class="form-group">
-	                    <label for="email" class="form-input-label<#if messagesPerField.existsError('email')> label-error</#if>">${msg("email")}</label>
+	                    <label for="email" class="form-input-label<#if messagesPerField.existsError('email')> label-error</#if>">${msg("email")} <span aria-hidden="true">${msg("requiredText")}</label>
 	                    <input type="text" id="email" class="form-input<#if messagesPerField.existsError('email')> input-error</#if>" name="email"
 	                           value="${(register.formData.email!'')}" autocomplete="email"
 	                           aria-invalid="<#if messagesPerField.existsError('email')>true</#if>"
+                             required
 	                    />
 	                    
 	                    <#if messagesPerField.existsError('email')>
@@ -131,10 +134,11 @@
 	
 	            <#if !realm.registrationEmailAsUsername>
 	                <div class="form-group">
-	                        <label for="username" class="form-input-label<#if messagesPerField.existsError('username')> label-error</#if>">${msg("username")}</label>
+	                        <label for="username" class="form-input-label<#if messagesPerField.existsError('username')> label-error</#if>">${msg("username")} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                        <input type="text" id="username" class="form-input<#if messagesPerField.existsError('username')> input-error</#if>" name="username"
 	                               value="${(register.formData.username!'')}" autocomplete="username"
 	                               aria-invalid="<#if messagesPerField.existsError('username')>true</#if>"
+                                 required
 	                        />
 	
 	                        <#if messagesPerField.existsError('username')>
@@ -149,13 +153,14 @@
 	
 	            <#if passwordRequired??>
 	                <div class="form-group">
-	                        <label for="password" class="form-input-label<#if messagesPerField.existsError('password')> label-error</#if>">${msg("password")}</label>
+	                        <label for="password" class="form-input-label<#if messagesPerField.existsError('password')> label-error</#if>">${msg("password")} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                        <input type="password" id="password" class="form-input<#if messagesPerField.existsError('password')> input-error</#if>" name="password"
-                                 aria-describedby="passwordRequirementsLabel passwordRequirements"
+                                 aria-describedby="password-requirements-label password-requirements"
 	                               autocomplete="new-password"
 	                               aria-invalid="<#if messagesPerField.existsError('password','password-confirm')>true</#if>"
                                  oninput="checkPasswordStrength(this.value)",
-                                  onblur="checkPasswordExposed(this.value)"
+                                 onblur="checkPasswordExposed(this.value)",
+                                 required
 	                        />
 	
                           <noscript>
@@ -185,13 +190,14 @@
                           </noscript>
 	                </div>
 
-                  <@password_strength.password_strength_feedback/>
+                  <@password_strength.password_strength_feedback />
 	
 	                <div class="form-group">
-	                        <label for="password-confirm" class="form-input-label<#if messagesPerField.existsError('password-confirm')> label-error</#if>">${msg("passwordConfirm")}</label>
+	                        <label for="password-confirm" class="form-input-label<#if messagesPerField.existsError('password-confirm')> label-error</#if>">${msg("passwordConfirm")} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                        <input type="password" id="password-confirm" class="form-input<#if messagesPerField.existsError('password-confirm')> input-error</#if>"
 	                               name="password-confirm"
 	                               aria-invalid="<#if messagesPerField.existsError('password-confirm')>true</#if>"
+                                 required
 	                        />
 	
 	                        <#if messagesPerField.existsError('password-confirm')>
@@ -212,8 +218,9 @@
 	                        <input type="checkbox" id="terms_of_use" class="form-input-checkbox <#if messagesPerField.existsError('terms_of_use')> input-error</#if>"
 	                               name="terms_of_use"
 	                               aria-invalid="<#if messagesPerField.existsError('terms_of_use')>true</#if>"
+                                 required
 	                        />
-	                        <label for="terms_of_use" class="form-input-label-not-bold<#if messagesPerField.existsError('terms_of_use')> label-error</#if>">${msg("termsOfUse")?no_esc}</label>
+	                        <label for="terms_of_use" class="form-input-label-not-bold<#if messagesPerField.existsError('terms_of_use')> label-error</#if>">${msg("termsOfUse")?no_esc} <span aria-hidden="true">${msg("requiredText")}</span></label>
 	                    </div>
 	                </div>
 	            </#if>

--- a/files/templates/mbta/login/resources/css/stylesheet.css
+++ b/files/templates/mbta/login/resources/css/stylesheet.css
@@ -87,6 +87,14 @@ h3 {
     .header-container {
         width: 70% !important;
     }
+
+    .required-pill {
+      font-size: 0.875rem;
+    }
+
+    .strength-container {
+      font-size: 0.875rem;
+    }
 }
 
 /* reduce content width for LG/XL breakpoint */
@@ -112,6 +120,14 @@ h3 {
 
     h3 {
         font-size: 1.4763rem;
+    }
+    
+    .required-pill {
+      font-size: 1rem;
+    }
+
+    .strength-container {
+      font-size: 1rem;
     }
 }
 
@@ -499,6 +515,7 @@ a:visited {
 
 .checkbox-input-group {
   display: flex;
+  align-items: center;
   gap: 0.5rem;
 }
 
@@ -557,13 +574,26 @@ a:visited {
   text-align: start;
 }
 
+
+.screen-reader-announcer {
+  position: absolute;
+	position: absolute !important;
+	width: 1px !important;
+	height: 1px !important;
+	padding: 0 !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	clip: rect(0,0,0,0) !important;
+	white-space: nowrap !important;
+	border: 0 !important;
+}
+
 .strength-description {
   margin: 0;
   padding-left: 1.5rem;
 }
 
 .strength-container {
-    font-size: 1rem;
     display: none;
     background-color: #F4F5F7;
     padding: .5rem;
@@ -642,29 +672,18 @@ a:visited {
     align-items: center;
 }
 
+
+.required-pill-text {
+  margin-left: 8px;
+}
+
 .required-pill.complete {
     background-color: #dff0d8;
-}
-
-.required-pill::before {
-    content: "";
-    width: 16px;
-    height: 16px;
-    background-image: url("../img/password-incomplete.svg");
-    margin-right: 8px;
-}
-
-.required-pill.complete::before {
-    background-image: url("../img/password-complete.svg");
 }
 
 .required-pill.error {
     background-color: #F2DEDE;
     color: #B3000F
-}
-
-.required-pill.error::before {
-    background-image: url("../img/password-required-error.svg");
 }
 
 .terms-of-use-title {

--- a/files/templates/mbta/login/resources/js/check-password-strength.js
+++ b/files/templates/mbta/login/resources/js/check-password-strength.js
@@ -1,6 +1,6 @@
 function checkPasswordStrength(password) {
   const { score, feedback } = zxcvbnts.core.zxcvbn(password);
-  const container = document.getElementById("strengthContainer");
+  const container = document.getElementById("strength-container");
 
   validatePills(password);
   if (!password || password.trim() === "") {

--- a/files/templates/mbta/login/resources/js/update-password-strength.js
+++ b/files/templates/mbta/login/resources/js/update-password-strength.js
@@ -26,7 +26,7 @@ function setupZxcvbnTranslations(translations) {
 }
 
 function updatePasswordStrength(score) {
-  const container = document.getElementById("strengthContainer");
+  const container = document.getElementById("strength-container");
   const label = document.querySelector(".strength-label");
 
   for (
@@ -80,21 +80,37 @@ function validatePills(password) {
   updatePill(requiredSpecialPill, hasSpecialCharacter);
   updatePill(requiredLengthPill, isLongEnough);
 
-  return (
-    hasUppercase &&
-    hasLowercase &&
-    hasNumber &&
-    hasSpecialCharacter &&
-    isLongEnough
-  );
+  const numberFulfilled = [
+    hasUppercase,
+    hasLowercase,
+    hasNumber,
+    hasSpecialCharacter,
+    isLongEnough,
+  ].filter(Boolean).length;
+
+  // TODO: Will need to get translations for this, and the complete/incomplete/error states underneath
+  document.getElementById("screen-reader-announcer").textContent =
+    `${numberFulfilled} of 5 requirements fulfilled`;
 }
 
 function updatePill(pill, conditionMet) {
   pill.classList.remove("error");
   if (conditionMet) {
     pill.classList.add("complete");
+    pill.querySelector(".required-pill-icon").src =
+      `${resourcesPath}/img/password-complete.svg`;
+    pill.setAttribute(
+      "aria-label",
+      `${pill.querySelector(".required-pill-text").textContent}, complete`,
+    );
   } else {
     pill.classList.remove("complete");
+    pill.querySelector(".required-pill-icon").src =
+      `${resourcesPath}/img/password-incomplete.svg`;
+    pill.setAttribute(
+      "aria-label",
+      `${pill.querySelector(".required-pill-text").textContent}, incomplete`,
+    );
   }
 }
 
@@ -109,5 +125,11 @@ function setPillErrors() {
 
   pills.forEach((pill) => {
     pill.classList.add("error");
+    pill.querySelector(".required-pill-icon").src =
+      `${resourcesPath}/img/password-required-error.svg`;
+    pill.setAttribute(
+      "aria-label",
+      `${pill.querySelector(".required-pill-text").textContent}, error`,
+    );
   });
 }


### PR DESCRIPTION
- fix for checkboxes not being centered on Safari,
- fix for password strength text sizes
- moved the icon for the requirement pill into an <img> instead of using ::before in order to better handle voiceover
- added Required label for required fields in registration
- voiceover will now announce the number of requirements fulfilled as users are typing
- voiceover will now allow users to hear fulfilled requirements by tabbing into the requirements section and hear strength/suggestions by tabbing into the next password strength section
- added placeholder translations for these new strings