### PR TITLE
style: increased body text size from 0.875rem to 1rem for small screens

### DIFF
--- a/files/templates/mbta/login/resources/css/stylesheet.css
+++ b/files/templates/mbta/login/resources/css/stylesheet.css
@@ -41,11 +41,7 @@ h3 {
 }
 
 /* smaller type for XS breakpoint */
-@media (max-width: 544px) {
-    body { 
-        font-size: 0.875rem;
-    }
-    
+@media (max-width: 544px) {  
     h1 { 
         font-size: 1.75rem;
     }


### PR DESCRIPTION
Default body size defined slightly higher is 1rem. 